### PR TITLE
SB-1759: Mock Response Play Resume

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1373,7 +1373,7 @@ Returns a specific Asset.
     ```js
     {
       "headers": {
-        
+
       },
       "data": {
         "distributor": {
@@ -19388,8 +19388,6 @@ List of viewed assets.
             "synopsisShort": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida.",
             "synopsis": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida, pero a un alto precio.",
             "duration": 3642,
-            "airDate": "2008-06-17T10:23:36Z",
-            "externalBillingId": "000557397",
             "parentalRating": {
                 "id": 9,
                 "title": "R"
@@ -19492,45 +19490,6 @@ List of viewed assets.
                 "billingType": "rental",
                 "price": "25.00"
             }
-        },
-        {
-            "headers": {"ttl": 0},
-            "data": {
-                "entity": "asset",
-                "category": "episode",
-                "parentShow": {
-                    "entity": "asset",
-                    "category": "series",
-                    "id": 11173
-                },
-                "id": 11174,
-                "modifiedAt": "2014-08-07T02:50:31Z",
-                "title": "Abusan de Griselda",
-                "titleShort": "Abusan de Griselda",
-                "synopsisShort": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida.",
-                "synopsis": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida, pero a un alto precio.",
-                "duration": 3642,
-                "airDate": "2008-06-17T10:23:36Z",
-                "externalBillingId": "000557397",
-                "parentalRating": {
-                    "id": 9,
-                    "title": "R"
-                },
-                "genre": {
-                    "id": 111,
-                    "title": "Acción y Aventura"
-                },
-                "publicationEvent": {
-                    "entity": "publicationEvent",
-                    "id": 18563,
-                    "modifiedAt": "2014-08-07T02:50:31Z",
-                    "startDate": "2014-04-09T06:00:00Z",
-                    "endDate": "2015-03-31T05:59:00Z",
-                    "billingType": "rental",
-                    "price": "25.00"
-                }
-            },
-            "messages": []
         }
       ],
       "messages": []
@@ -19555,185 +19514,267 @@ Retrieves the info for the given asset.
     {
         "headers": {"ttl": 0},
         "data": {
-            "entity": "asset",
-            "category": "movie",
-            "parentShow": null,
-            "id": 4754,
-            "modifiedAt": "2014-08-07T02:50:31Z",
-            "title": "Operación Dragón",
-            "titleShort": "Operación Dragón",
-            "synopsisShort": "Un maestro de artes marciales decide espiar a un solitario criminal usando su invitación a un torneo.",
-            "synopsis": "Un maestro de artes marciales decide espiar a un solitario criminal usando su invitación a un torneo. Es la película que tras estrenarse en Hong Kong, dio a conocer a Bruce Lee en Estados Unidos.",
-            "keywords": [
-                "dragon",
-                "ball"
+          "distributor": {
+            "entity": "distributor",
+            "id": 2,
+            "title": "ondemand"
+          },
+          "duration": 7680,
+          "entity": "asset",
+          "genre": {
+            "entity": "genre",
+            "id": 9,
+            "items": [
+              {
+                "entity": "genre",
+                "id": 834,
+                "items": [],
+                "parent": {
+                  "id": 9
+                },
+                "title": "Drama 1-1"
+              },
+              {
+                "entity": "genre",
+                "id": 832,
+                "items": [],
+                "parent": {
+                  "id": 9
+                },
+                "title": "Drama 1"
+              },
+              {
+                "entity": "genre",
+                "id": 835,
+                "items": [],
+                "parent": {
+                  "id": 9
+                },
+                "title": "Drama 2"
+              }
             ],
-            "duration": 3642,
-            "airDate": "2008-06-17T10:23:36Z",
-            "externalBillingId": "000557397",
-            "parentalRating": {
-                "id": 9,
-                "title": "R"
-            },
-            "genre": {
-                "id": 111,
-                "title": "Acción y Aventura"
-            },
-            "otherGenres": [
+            "parent": null,
+            "title": "Dram"
+          },
+          "id": 19882,
+          "keywords": null,
+          "modifiedAt": "2015-05-17T15:04:34Z",
+          "otherGenres": [
+            {
+              "entity": "genre",
+              "id": 9,
+              "items": [
                 {
-                    "id": 111,
-                    "title": "Acción y Aventura"
+                  "entity": "genre",
+                  "id": 834,
+                  "items": [],
+                  "parent": {
+                    "id": 9
+                  },
+                  "title": "Drama 1-1"
                 },
                 {
-                    "id": 112,
-                    "title": "Dibujos Animados"
+                  "entity": "genre",
+                  "id": 832,
+                  "items": [],
+                  "parent": {
+                    "id": 9
+                  },
+                  "title": "Drama 1"
+                },
+                {
+                  "entity": "genre",
+                  "id": 835,
+                  "items": [],
+                  "parent": {
+                    "id": 9
+                  },
+                  "title": "Drama 2"
                 }
-            ],
-            "distributor": {
-                "id": 12,
-                "title": "Warner Bros."
-            },
-            "studio": {
-                "id": 22,
-                "title": "WDD"
-            },
-            "people": [
-                {
-                    "id": 7312,
-                    "category": "actor",
-                    "displayName": "John Saxon"
-                },
-                {
-                    "id": 7313,
-                    "category": "actor",
-                    "displayName": "Bruce Lee"
-                },
-                {
-                    "id": 7314,
-                    "category": "director",
-                    "displayName": "Robert Clouse"
-                },
-                {
-                    "id": 15010,
-                    "category": "actor",
-                    "displayName": "Jim Kelly"
-                },
-                {
-                    "id": 15011,
-                    "category": "actor",
-                    "displayName": "Ahna Capri"
-                }
-            ],
-            "pictures": [
-                {
-                    "entity": "picture",
-                    "id": 2853,
-                    "modifiedAt": "2014-03-28T00:25:46Z",
-                    "credits": "Tom Smith",
-                    "orientation": "portrait",
-                    "pictureType": "poster",
-                    "title": "",
-                    "versions": [
-                        {
-                            "profile": "webLandscapeSmall",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile150Image.jpg",
-                            "width": "192",
-                            "height": "108"
-                        },
-                        {
-                            "profile": "webLandscapeMedium",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "224",
-                            "height": "126"
-                        },
-                        {
-                            "profile": "webLandscapeLarge",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "384",
-                            "height": "216"
-                        },
-                        {
-                            "profile": "mobileLandscapeSmall",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "96",
-                            "height": "54"
-                        },
-                        {
-                            "profile": "mobileLandscapeMedium",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "160",
-                            "height": "90"
-                        },
-                        {
-                            "profile": "mobileLandscapeLarge",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "320",
-                            "height": "180"
-                        },
-                        {
-                            "profile": "mobileRetinaLandscapeSmall",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "192",
-                            "height": "108"
-                        },
-                        {
-                            "profile": "mobileRetinaLandscapeMedium",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "320",
-                            "height": "180"
-                        },
-                        {
-                            "profile": "mobileRetinaLandscapeLarge",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "640",
-                            "height": "360"
-                        }
-                    ]
-                }
-            ],
-            "videos": [
-                {
-                    "entity": "video",
-                    "id": 4533,
-                    "audioLanguage": {
-                        "id": 3,
-                        "title": "English"
-                    },
-                    "audioType": "stereo",
-                    "definition": "SD",
-                    "duration": 3642,
-                    "files": [
-                        {
-                           "path": "http://vodhds-video.cablevision.veo.tv/veo_4533/veo_4533__CV_MP4_SD_16x9_1600kbps_640x480_29.97fps.f4m",
-                           "type": "hds"
-                        },
-                        {
-                           "path": "http://vodhls-video.cablevision.veo.tv/veo_4533__CV/veo_4533__CV.m3u8",
-                           "type": "hls"
-                        },
-                        {
-                           "path": "http://vodss-video.cablevision.veo.tv/veo_4533__CV/veo_4533__CV.ism/Manifest",
-                           "type": "ss"
-                        }
-                    ],
-                    "resolution": "480i",
-                    "screenFormat": "widescreen",
-                    "videoType": "full"
-                }
-            ],
-            "publicationEvent": {
-                "entity": "publicationEvent",
-                "id": 18563,
-                "modifiedAt": "2014-08-07T02:50:31Z",
-                "startDate": "2014-04-09T06:00:00Z",
-                "endDate": "2015-03-31T05:59:00Z",
-                "billingType": "rental",
-                "price": "25.00"
-            },
-            "view": {
-              "position" : 20,
-              "current"  : false
+              ],
+              "parent": null,
+              "title": "Dram"
             }
+          ],
+          "people": [
+            {
+              "category": "actor",
+              "displayName": "Josh Brolin",
+              "entity": "person",
+              "id": 21696
+            },
+            {
+              "category": "actor",
+              "displayName": "Sean Penn",
+              "entity": "person",
+              "id": 21697
+            },
+            {
+              "category": "actor",
+              "displayName": "Emile Hirsch",
+              "entity": "person",
+              "id": 21698
+            },
+            {
+              "category": "director",
+              "displayName": "Gus Van Sant",
+              "entity": "person",
+              "id": 21699
+            },
+            {
+              "category": "actor",
+              "displayName": "Diego Luna",
+              "entity": "person",
+              "id": 21888
+            },
+            {
+              "category": "actor",
+              "displayName": "James Franco",
+              "entity": "person",
+              "id": 21889
+            },
+            {
+              "category": "actor",
+              "displayName": "Alison Pill",
+              "entity": "person",
+              "id": 21890
+            }
+          ],
+          "pictures": [
+            {
+              "entity": "picture",
+              "id": 12968,
+              "pictureType": "poster",
+              "title": "ASST0000000001357145_Milk_SD_Package.png",
+              "versions": [
+                {
+                  "entity": "pictureImage",
+                  "height": 99,
+                  "id": 701846,
+                  "width": 66,
+                  "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_12968_profile100Image.png",
+                  "profile": "webPortraitSmall"
+                },
+                {
+                  "entity": "pictureImage",
+                  "height": 204,
+                  "id": 701847,
+                  "width": 136,
+                  "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_12968_profile101Image.png",
+                  "profile": "webPortraitMedium"
+                },
+                {
+                  "entity": "pictureImage",
+                  "height": 330,
+                  "id": 701848,
+                  "width": 220,
+                  "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_12968_profile102Image.png",
+                  "profile": "webPortraitLarge"
+                },
+                {
+                  "entity": "pictureImage",
+                  "height": 90,
+                  "id": 701852,
+                  "width": 60,
+                  "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_12968_profile200Image.png",
+                  "profile": "iPhonePortrait"
+                },
+                {
+                  "entity": "pictureImage",
+                  "height": 180,
+                  "id": 701853,
+                  "width": 120,
+                  "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_12968_profile220Image.png",
+                  "profile": "iPhoneRetinaPortrait"
+                },
+                {
+                  "entity": "pictureImage",
+                  "height": 192,
+                  "id": 701860,
+                  "width": 128,
+                  "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_12968_profile300Image.png",
+                  "profile": "iPadPortraitSmall"
+                },
+                {
+                  "entity": "pictureImage",
+                  "height": 309,
+                  "id": 701861,
+                  "width": 206,
+                  "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_12968_profile301Image.png",
+                  "profile": "iPadPortraitLarge"
+                }
+              ]
+            }
+          ],
+          "studio": {
+            "entity": "studio",
+            "id": 6,
+            "title": "UNIVERSAL"
+          },
+          "synopsis": "Hoy, en el D\u00eda Internacional contra la Homfobia, recordamos a Harvey Milk, un incansable activista y pol\u00edtico interpretado por Sean Penn en \"Milk\".",
+          "synopsisShort": "Hoy, en el D\u00eda Internacional contra la Homfobia, recordamos a Harvey Milk, un incansable activista y pol\u00edtico interpretado por Sean Penn en \"Milk\".",
+          "title": "Mi Nombre es Harvey Milk",
+          "titleSeo": "",
+          "titleShort": "Mi Nombre es Harvey Milk",
+          "category": "movie",
+          "airDate": "2015-01-26T06:00:00Z",
+          "parentalRating": {
+            "entity": "parentalRating",
+            "id": 9,
+            "items": [],
+            "parent": null,
+            "title": "R"
+          },
+          "publicationEvent": {
+            "billingType": "rental",
+            "endDate": "2015-10-25T05:59:00Z",
+            "entity": "publicationEvent",
+            "id": 73373,
+            "price": "25.00",
+            "startDate": "2015-01-26T06:00:00Z"
+          },
+          "videos": [
+            {
+              "definition": "SD",
+              "duration": 7689,
+              "entity": "video",
+              "files": [
+                {
+                  "entity": "videoFile",
+                  "id": 141785,
+                  "path": "http:\/\/vodhds-video.cablevision.veo.tv\/veo_19387\/veo_19387__CV_MP4_SD_16x9_1600kbps_640x480_29.97fps.f4m",
+                  "type": "hds"
+                },
+                {
+                  "entity": "videoFile",
+                  "id": 141786,
+                  "path": "http:\/\/vodhls-video.cablevision.veo.tv\/veo_19387__CV\/veo_19387__CV.m3u8",
+                  "type": "hls"
+                },
+                {
+                  "entity": "videoFile",
+                  "id": 141787,
+                  "type": "isma"
+                },
+                {
+                  "entity": "videoFile",
+                  "id": 141788,
+                  "path": "http:\/\/vodss-video.cablevision.veo.tv\/veo_19387__CV\/veo_19387__CV.ism\/Manifest",
+                  "type": "ss"
+                },
+                {
+                  "entity": "videoFile",
+                  "id": 141789,
+                  "type": "ismc"
+                }
+              ],
+              "id": 19387
+            }
+          ],
+          "averageRating": 3,
+          "view": {
+            "position" : 20
+          }
         },
         "messages": []
     }
@@ -19743,258 +19784,631 @@ Retrieves the info for the given asset.
 
     ```js
     {
-        "headers": {"ttl": 0},
-        "data": {
-            "entity": "asset",
-            "category": "series",
-            "parentShow": null,
-            "id": 11173,
-            "modifiedAt": "2014-08-07T02:50:31Z",
-            "title": "La Viuda Negra",
-            "titleShort": "La Viuda Negra",
-            "synopsisShort": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida.",
-            "synopsis": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida, pero a un alto precio.",
-            "keywords": [
-                "dragon",
-                "ball"
-            ],
-            "duration": 3642,
-            "airDate": "2008-06-17T10:23:36Z",
-            "externalBillingId": "000557397",
-            "parentalRating": {
-                "id": 9,
-                "title": "R"
-            },
-            "genre": {
-                "id": 111,
-                "title": "Acción y Aventura"
-            },
-            "otherGenres": [
-                {
-                    "id": 111,
-                    "title": "Acción y Aventura"
-                },
-                {
-                    "id": 112,
-                    "title": "Dibujos Animados"
-                }
-            ],
-            "distributor": {
-                "id": 12,
-                "title": "Warner Bros."
-            },
-            "studio": {
-                "id": 22,
-                "title": "WDD"
-            },
-            "people": [
-                {
-                    "id": 7312,
-                    "category": "actor",
-                    "displayName": "John Saxon"
-                },
-                {
-                    "id": 7313,
-                    "category": "actor",
-                    "displayName": "Bruce Lee"
-                },
-                {
-                    "id": 7314,
-                    "category": "director",
-                    "displayName": "Robert Clouse"
-                },
-                {
-                    "id": 15010,
-                    "category": "actor",
-                    "displayName": "Jim Kelly"
-                },
-                {
-                    "id": 15011,
-                    "category": "actor",
-                    "displayName": "Ahna Capri"
-                }
-            ],
-            "pictures": [
-                {
-                    "entity": "picture",
-                    "id": 2853,
-                    "modifiedAt": "2014-03-28T00:25:46Z",
-                    "credits": "Tom Smith",
-                    "orientation": "portrait",
-                    "pictureType": "poster",
-                    "title": "",
-                    "versions": [
-                        {
-                            "profile": "webLandscapeSmall",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile150Image.jpg",
-                            "width": "192",
-                            "height": "108"
-                        },
-                        {
-                            "profile": "webLandscapeMedium",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "224",
-                            "height": "126"
-                        },
-                        {
-                            "profile": "webLandscapeLarge",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "384",
-                            "height": "216"
-                        },
-                        {
-                            "profile": "mobileLandscapeSmall",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "96",
-                            "height": "54"
-                        },
-                        {
-                            "profile": "mobileLandscapeMedium",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "160",
-                            "height": "90"
-                        },
-                        {
-                            "profile": "mobileLandscapeLarge",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "320",
-                            "height": "180"
-                        },
-                        {
-                            "profile": "mobileRetinaLandscapeSmall",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "192",
-                            "height": "108"
-                        },
-                        {
-                            "profile": "mobileRetinaLandscapeMedium",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "320",
-                            "height": "180"
-                        },
-                        {
-                            "profile": "mobileRetinaLandscapeLarge",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "640",
-                            "height": "360"
-                        }
-                    ]
-                }
-            ],
-            "seasons": [
-                {
-                    "entity": "season",
-                    "id": 451,
-                    "title": null,
-                    "number": 1,
-                    "episodeCount": 0,
-                    "airDate": "2008-06-17T10:23:36Z",
-                    "episodes": [
-                        {
-                            "entity": "asset",
-                            "category": "episode",
-                            "id": 11392,
-                            "episodeNumber": 40,
-                            "title": "Fuera de todo plan",
-                            "titleShort": "Fuera de todo plan",
-                            "synopsisShort": "El Legado",
-                            "pictures": [
-                                {
-                                    "entity": "picture",
-                                    "id": 2853,
-                                    "modifiedAt": "2014-03-28T00:25:46Z",
-                                    "pictureType": "poster",
-                                    "title": ""
-                                }
-                            ],
-                            "view": {
-                              "position" : 30,
-                              "current"  : true
-                            }
-                        },
-                        {
-                            "entity": "asset",
-                            "category": "episode",
-                            "id": 11569,
-                            "episodeNumber": 39,
-                            "title": "Griselda se confiesa",
-                            "titleShort": "Griselda se confiesa",
-                            "synopsisShort": "Griselda le cuenta a una guardia del reclusorio que Jones le confesó su amor y que nunca trató de hacerle daño. Mientras, Otálvaro planea la venganza por la muerte de su sobrina.",
-                            "pictures": [
-                                {
-                                    "entity": "picture",
-                                    "id": 2853,
-                                    "modifiedAt": "2014-03-28T00:25:46Z",
-                                    "pictureType": "poster",
-                                    "title": ""
-                                }
-                            ],
-                            "view": {
-                              "position" : 22,
-                              "current"  : false
-                            }
-                        }
-                    ]
-                },
-                {
-                    "entity": "season",
-                    "id": 462,
-                    "title": null,
-                    "number": 2,
-                    "episodeCount": 0,
-                    "airDate": "2008-06-17T10:23:36Z",
-                    "episodes": [
-                        {
-                            "entity": "asset",
-                            "category": "episode",
-                            "id": 12780,
-                            "episodeNumber": 81,
-                            "title": "El Legado",
-                            "titleShort": "El Legado",
-                            "synopsisShort": "Griselda se ve enfrentada a una trampa de García mientras Jones se encarga del rescate. García finalmente embosca a Griselda y a Richie, quienes deciden llevar a cabo un plan para evitar ser capturados. Michael toma cartas en este asunto y pone en la mira a García.",
-                            "pictures": [
-                                {
-                                    "entity": "picture",
-                                    "id": 2853,
-                                    "modifiedAt": "2014-03-28T00:25:46Z",
-                                    "pictureType": "poster",
-                                    "title": ""
-                                }
-                            ]
-                        },
-                        {
-                            "entity": "asset",
-                            "category": "episode",
-                            "id": 12781,
-                            "episodeNumber": 80,
-                            "title": "Lucha de astucias",
-                            "titleShort": "Lucha de astucias",
-                            "synopsisShort": "Jennifer rescata a Jones de un barranco, en tanto que Griselda y Silvio finalmente se enfrentan: sólo uno saldrá con vida. Jennifer y Jones tienen claro que capturar a Griselda es ahora su prioridad.",
-                            "pictures": [
-                                {
-                                    "entity": "picture",
-                                    "id": 2853,
-                                    "modifiedAt": "2014-03-28T00:25:46Z",
-                                    "pictureType": "poster",
-                                    "title": ""
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ],
-            "videos": [],
-            "publicationEvent": {
-                "entity": "publicationEvent",
-                "id": 18563,
-                "modifiedAt": "2014-08-07T02:50:31Z",
-                "startDate": "2014-04-09T06:00:00Z",
-                "endDate": "2015-03-31T05:59:00Z",
-                "billingType": "rental",
-                "price": "25.00"
-            }
+      "headers": {
+
+      },
+      "data": {
+        "distributor": {
+          "entity": "distributor",
+          "id": 1,
+          "title": "televisa.networks.mx"
         },
-        "messages": []
+        "duration": 0,
+        "entity": "asset",
+        "genre": {
+          "entity": "genre",
+          "id": 102,
+          "items": [],
+          "parent": null,
+          "title": "Comedia"
+        },
+        "id": 71,
+        "keywords": null,
+        "modifiedAt": "2015-04-14T22:12:32Z",
+        "otherGenres": [
+          {
+            "entity": "genre",
+            "id": 102,
+            "items": [],
+            "parent": null,
+            "title": "Comedia"
+          }
+        ],
+        "people": [
+          {
+            "category": "actor",
+            "displayName": "Ren\u00e9 Franco Velasco",
+            "entity": "person",
+            "id": 220
+          },
+          {
+            "category": "actor",
+            "displayName": "Mart\u00edn Sobrino Lavalle",
+            "entity": "person",
+            "id": 221
+          },
+          {
+            "category": "actor",
+            "displayName": "Juan Francisco Matencio Calderon De La Barca",
+            "entity": "person",
+            "id": 222
+          },
+          {
+            "category": "actor",
+            "displayName": "Karla G\u00f3mez",
+            "entity": "person",
+            "id": 223
+          },
+          {
+            "category": "director",
+            "displayName": "Ren\u00e9 Franco Velasco",
+            "entity": "person",
+            "id": 224
+          },
+          {
+            "category": "producer",
+            "displayName": "Juan Francisco Matencio Calderon De La Barca",
+            "entity": "person",
+            "id": 225
+          }
+        ],
+        "pictures": [
+          {
+            "entity": "picture",
+            "id": 42,
+            "pictureType": "frame",
+            "title": "201208270299.jpg",
+            "versions": [
+              {
+                "entity": "pictureImage",
+                "height": 576,
+                "id": 46515,
+                "width": 1024,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_image.jpg",
+                "profile": "main"
+              },
+              {
+                "entity": "pictureImage",
+                "height": null,
+                "id": 46516,
+                "width": null,
+                "link": null,
+                "profile": "webPortraitSmall"
+              },
+              {
+                "entity": "pictureImage",
+                "height": null,
+                "id": 46517,
+                "width": null,
+                "link": null,
+                "profile": "webPortraitMedium"
+              },
+              {
+                "entity": "pictureImage",
+                "height": null,
+                "id": 46518,
+                "width": null,
+                "link": null,
+                "profile": "webPortraitLarge"
+              },
+              {
+                "entity": "pictureImage",
+                "height": null,
+                "id": 46522,
+                "width": null,
+                "link": null,
+                "profile": "iPhonePortrait"
+              },
+              {
+                "entity": "pictureImage",
+                "height": null,
+                "id": 46523,
+                "width": null,
+                "link": null,
+                "profile": "iPhoneRetinaPortrait"
+              },
+              {
+                "entity": "pictureImage",
+                "height": null,
+                "id": 46530,
+                "width": null,
+                "link": null,
+                "profile": "iPadPortraitSmall"
+              },
+              {
+                "entity": "pictureImage",
+                "height": null,
+                "id": 46531,
+                "width": null,
+                "link": null,
+                "profile": "iPadPortraitLarge"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 108,
+                "id": 386313,
+                "width": 192,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile150Image.jpg",
+                "profile": "webLandscapeSmall"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 126,
+                "id": 386314,
+                "width": 224,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile151Image.jpg",
+                "profile": "webLandscapeMedium"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 216,
+                "id": 386315,
+                "width": 384,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile152Image.jpg",
+                "profile": "webLandscapeLarge"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 54,
+                "id": 386318,
+                "width": 96,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile250Image.jpg",
+                "profile": "iPhoneLandscapeSmall"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 90,
+                "id": 386319,
+                "width": 160,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile251Image.jpg",
+                "profile": "iPhoneLandscapeMedium"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 180,
+                "id": 386320,
+                "width": 320,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile252Image.jpg",
+                "profile": "iPhoneLandscapeLarge"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 108,
+                "id": 386321,
+                "width": 192,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile270Image.jpg",
+                "profile": "iPhoneRetinaLandscapeSmall"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 180,
+                "id": 386322,
+                "width": 320,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile271Image.jpg",
+                "profile": "iPhoneRetinaLandscapeMedium"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 360,
+                "id": 386323,
+                "width": 640,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile272Image.jpg",
+                "profile": "iPhoneRetinaLandscapeLarge"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 270,
+                "id": 386326,
+                "width": 480,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile350Image.jpg",
+                "profile": "iPadLandscape1"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 243,
+                "id": 386327,
+                "width": 432,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile351Image.jpg",
+                "profile": "iPadLandscape2"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 207,
+                "id": 386328,
+                "width": 368,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile352Image.jpg",
+                "profile": "iPadLandscape3"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 162,
+                "id": 386329,
+                "width": 288,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile353Image.jpg",
+                "profile": "iPadLandscape4"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 144,
+                "id": 386330,
+                "width": 256,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile354Image.jpg",
+                "profile": "iPadLandscape5"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 126,
+                "id": 386331,
+                "width": 224,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile355Image.jpg",
+                "profile": "iPadLandscape6"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 117,
+                "id": 386332,
+                "width": 208,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile356Image.jpg",
+                "profile": "iPadLandscape7"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 90,
+                "id": 386333,
+                "width": 160,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile357Image.jpg",
+                "profile": "iPadLandscape8"
+              },
+              {
+                "entity": "pictureImage",
+                "height": 81,
+                "id": 386334,
+                "width": 144,
+                "link": "https:\/\/dyv52uavm19r4.cloudfront.net\/prod\/Picture\/C_1_Picture_42_profile358Image.jpg",
+                "profile": "iPadLandscape9"
+              }
+            ]
+          }
+        ],
+        "studio": null,
+        "synopsis": "Divi\u00e9rtete con el talk show de uno de los conductores m\u00e1s irreverentes y din\u00e1micos que tiene la pantalla: Ren\u00e9 Franco.",
+        "synopsisShort": "Divi\u00e9rtete con el talk show de uno de los conductores m\u00e1s irreverentes y din\u00e1micos que tiene la pantalla: Ren\u00e9 Franco.",
+        "title": "Es de Noche y ya Llegu\u00e9",
+        "titleSeo": "",
+        "titleShort": "Es de Noche y ya Llegue",
+        "category": "series",
+        "seasons": [
+          {
+            "airDate": null,
+            "entity": "season",
+            "episodeCount": 15,
+            "episodes": [
+              {
+                "duration": 4620,
+                "entity": "asset",
+                "episodeNumber": 1,
+                "id": 75,
+                "pictures": [],
+                "synopsis": "Esta noche la incomparable voz de Natalia Sosa, el comediante Gustavo Mungu\u00eda; y en la m\u00fasica, Babas\u00f3nicos, Mart\u00edn sobrino y los due\u00f1os del segundo piso.\n",
+                "title": "Episodio 1",
+                "category": "episode",
+                "view": {
+                  "position" : 11,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4500,
+                "entity": "asset",
+                "episodeNumber": 2,
+                "id": 78,
+                "pictures": [],
+                "synopsis": "Esta noche la suegra de M\u00e9xico, Do\u00f1a Lucha, el gur\u00fa Ruben Carvajal y en la m\u00fasica R\u00edo Roma.\n",
+                "title": "Episodio 2",
+                "category": "episode",
+                "view": {
+                  "position" : 350,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4620,
+                "entity": "asset",
+                "episodeNumber": 3,
+                "id": 81,
+                "pictures": [],
+                "synopsis": "Esta noche los productores de Broadway Guillermo Wiechers y Juan Torres; los aut\u00e9nticos magos reyes Ari Sandy, El Mago de la Media Barba y el Mago Herrera; y en la m\u00fasica Pablo Montero.\n",
+                "title": "Episodio 3",
+                "category": "episode",
+                "view": {
+                  "position" : 230,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4620,
+                "entity": "asset",
+                "episodeNumber": 4,
+                "id": 77,
+                "pictures": [],
+                "synopsis": "Esta noche un abismo de pasi\u00f3n; Angelique Boyer, Mark Tacher y David Zepeda; la voz de M\u00e9xico, Oscar Cruz y en la m\u00fasica; Jot Dog y Juan Carlos Lozano.\n",
+                "title": "Episodio 4",
+                "category": "episode",
+                "view": {
+                  "position" : 34,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4620,
+                "entity": "asset",
+                "episodeNumber": 5,
+                "id": 76,
+                "pictures": [],
+                "synopsis": "Esta noche la esencia del perfume Sebasti\u00e1n Rulli; el mejor imitador de M\u00e9xico, Gilberto Gless. Joserra y en la m\u00fasica, La \u00danica Internacional Sonora Santanera.\n",
+                "title": "Episodio 5",
+                "category": "episode",
+                "view": {
+                  "position" : 30,
+                  "current"  : true
+                }
+              },
+              {
+                "duration": 4500,
+                "entity": "asset",
+                "episodeNumber": 6,
+                "id": 79,
+                "pictures": [],
+                "synopsis": "Esta noche Kika Edgar, Flavio Medina, Gloria Aura y Alex de la Madrid. Edgar Vivar, Sabrina y en la m\u00fasica, La Arrolladora Banda El Lim\u00f3n.\n",
+                "title": "Episodio 6",
+                "category": "episode",
+                "view": {
+                  "position" : 314,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4560,
+                "entity": "asset",
+                "episodeNumber": 7,
+                "id": 74,
+                "pictures": [],
+                "synopsis": "Esta noche Jaime Mauss\u00e1n, Mar\u00eda Jos\u00e9, Omar Chaparro y en la m\u00fasica, Kinky.\n",
+                "title": "Episodio 7",
+                "category": "episode",
+                "view": {
+                  "position" : 342,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4500,
+                "entity": "asset",
+                "episodeNumber": 11,
+                "id": 73,
+                "pictures": [],
+                "synopsis": "Esta noche la suegra de M\u00e9xico, Do\u00f1a Lucha, el gur\u00fa Ruben Carvajal y en la m\u00fasica R\u00edo Roma.\n",
+                "title": "Episodio 11",
+                "category": "episode",
+                "view": {
+                  "position" : 314,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4740,
+                "entity": "asset",
+                "episodeNumber": 15,
+                "id": 2980,
+                "pictures": [],
+                "synopsis": "Esta noche Chabelo, Marisol Gonzalez, Enrique Burak, Fernando Platas y Francisco Javier Gonz\u00e1lez. Y en la m\u00fasica, Paquita la del barrio.",
+                "title": "Episodio 15",
+                "category": "episode",
+                "view": {
+                  "position" : 346,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4560,
+                "entity": "asset",
+                "episodeNumber": 16,
+                "id": 2951,
+                "pictures": [],
+                "synopsis": "Esta noche Joaqu\u00edn Cordero, Jorge Falc\u00f3n y en la m\u00fasica, Carlos Cuevas.",
+                "title": "Episodio 16",
+                "category": "episode",
+                "view": {
+                  "position" : 634,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4440,
+                "entity": "asset",
+                "episodeNumber": 17,
+                "id": 2952,
+                "pictures": [],
+                "synopsis": "Esta noche el actor Julio Bracho, Gianmarco, la imaginaci\u00f3n de Mayumana y en la m\u00fasica, R\u00edo Roma.",
+                "title": "Episodio 17",
+                "category": "episode",
+                "view": {
+                  "position" : 374,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4620,
+                "entity": "asset",
+                "episodeNumber": 18,
+                "id": 2971,
+                "pictures": [],
+                "synopsis": "Esta noche del punto al punto G de Karina Velasco, la pareja maravilla Felipe N\u00e1jera y Jaime Morales, Mois\u00e9s Su\u00e1rez y en la m\u00fasica, Circo Pop y Dan Masciarelli.",
+                "title": "Episodio 18",
+                "category": "episode",
+                "view": {
+                  "position" : 3466,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4500,
+                "entity": "asset",
+                "episodeNumber": 19,
+                "id": 2953,
+                "pictures": [],
+                "synopsis": "Esta noche un panorama desde el puente con Sara Maldonado, Fabi\u00e1n Robles y Mauricio Mart\u00ednez, Israel Jaitovich y Roxanna Castellanos y Gustavo Mungu\u00eda, Ricardo Casta\u00f1eda y en la m\u00fasica Johnny Laboriel.",
+                "title": "Episodio 19",
+                "category": "episode",
+                "view": {
+                  "position" : 3433,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4620,
+                "entity": "asset",
+                "episodeNumber": 20,
+                "id": 2955,
+                "pictures": [],
+                "synopsis": "Esta noche buen Rock and Roll con Julissa, la eterna juventud de Pierre Angelo, Francisco Javier Gonz\u00e1lez y Carolina Mor\u00e1n y en la m\u00fasica, La Apuesta.",
+                "title": "Episodio 20",
+                "category": "episode",
+                "view": {
+                  "position" : 346,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4680,
+                "entity": "asset",
+                "episodeNumber": 21,
+                "id": 2956,
+                "pictures": [],
+                "synopsis": "Esta noche Los hermanos Castro, Sandra Echeverr\u00eda, Sandra Montoya y en la m\u00fasica, Mar\u00eda Jos\u00e9.",
+                "title": "Episodio 21",
+                "category": "episode",
+                "view": {
+                  "position" : 134,
+                  "current"  : false
+                }
+              }
+            ],
+            "id": 7,
+            "number": 1,
+            "title": ""
+          },
+          {
+            "airDate": null,
+            "entity": "season",
+            "episodeCount": 6,
+            "episodes": [
+              {
+                "duration": 4680,
+                "entity": "asset",
+                "episodeNumber": 8,
+                "id": 2978,
+                "pictures": [],
+                "synopsis": "Esta noche Miguel el Piojo Herrera, Sexo para el fin del mundo con Silvia Olmedo y en la m\u00fasica Ha-ash.",
+                "title": "Episodio 8",
+                "category": "episode",
+                "view": {
+                  "position" : 341,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4860,
+                "entity": "asset",
+                "episodeNumber": 9,
+                "id": 2990,
+                "pictures": [],
+                "synopsis": "Esta noche el villano por naturaleza Salvador Pineda, desde la tierra de Oz Adriana Riveramelo y Mauricio Clark, en la m\u00fasica OV7.",
+                "title": "Episodio 9",
+                "category": "episode",
+                "view": {
+                  "position" : 34,
+                  "current"  : true
+                }
+              },
+              {
+                "duration": 4680,
+                "entity": "asset",
+                "episodeNumber": 10,
+                "id": 2954,
+                "pictures": [],
+                "synopsis": "Esta noche la edec\u00e1n del debate Julia Orayen, Luis de Llano, Arath de la Torre, el Macaco y en la m\u00fasica Playa Limbo.",
+                "title": "Episodio 10",
+                "category": "episode"
+              },
+              {
+                "duration": 4500,
+                "entity": "asset",
+                "episodeNumber": 12,
+                "id": 2981,
+                "pictures": [],
+                "synopsis": "Esta noche sin censura Polo Polo, Sammy, Cirque \u00c9loize ID y en la m\u00fasica Moenia.",
+                "title": "Episodio 12",
+                "category": "episode",
+                "view": {
+                  "position" : 349,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4860,
+                "entity": "asset",
+                "episodeNumber": 13,
+                "id": 3011,
+                "pictures": [],
+                "synopsis": "Esta noche Rogelio Guerra, Christian Chavez, Iv\u00e1n S\u00e1nchez y en la m\u00fasica el Instituto Mexicano del Sonido.",
+                "title": "Episodio 13",
+                "category": "episode",
+                "view": {
+                  "position" : 834,
+                  "current"  : false
+                }
+              },
+              {
+                "duration": 4800,
+                "entity": "asset",
+                "episodeNumber": 14,
+                "id": 2972,
+                "pictures": [],
+                "synopsis": "Esta noche Ignacio L\u00f3pez Tarso, Sherlyn, Los Insignificantes y en la m\u00fasica Ana Victoria.",
+                "title": "Episodio 14",
+                "category": "episode",
+                "view": {
+                  "position" : 734,
+                  "current"  : false
+                }
+              }
+            ],
+            "id": 119,
+            "number": 1,
+            "title": ""
+          }
+        ],
+        "airDate": "2012-01-03T00:00:00Z",
+        "parentalRating": {
+          "entity": "parentalRating",
+          "id": 3,
+          "items": [],
+          "parent": null,
+          "title": "PG-13"
+        },
+        "publicationEvent": {
+          "billingType": "subscription",
+          "endDate": "2020-12-31T23:59:00Z",
+          "entity": "publicationEvent",
+          "id": 271,
+          "price": "0.00",
+          "startDate": "2012-01-03T00:00:00Z"
+        },
+        "videos": [],
+        "averageRating": 5
+      },
+      "messages": []
     }
     ```
 
@@ -20002,194 +20416,128 @@ Retrieves the info for the given asset.
 
     ```js
     {
-        "headers": {"ttl": 0},
-        "data": {
-            "entity": "asset",
-            "category": "episode",
-            "parentShow": {
-                "entity": "asset",
-                "category": "series",
-                "id": 11173
-            },
-            "id": 11174,
-            "modifiedAt": "2014-08-07T02:50:31Z",
-            "title": "Abusan de Griselda",
-            "titleShort": "Abusan de Griselda",
-            "synopsisShort": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida.",
-            "synopsis": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida, pero a un alto precio.",
-            "keywords": [
-                "dragon",
-                "ball"
-            ],
-            "duration": 3642,
-            "airDate": "2008-06-17T10:23:36Z",
-            "externalBillingId": "000557397",
-            "parentalRating": {
-                "id": 9,
-                "title": "R"
-            },
-            "genre": {
-                "id": 111,
-                "title": "Acción y Aventura"
-            },
-            "otherGenres": [
-                {
-                    "id": 111,
-                    "title": "Acción y Aventura"
-                },
-                {
-                    "id": 112,
-                    "title": "Dibujos Animados"
-                }
-            ],
-            "distributor": {
-                "id": 12,
-                "title": "Warner Bros."
-            },
-            "studio": {
-                "id": 22,
-                "title": "WDD"
-            },
-            "people": [
-                {
-                    "id": 7312,
-                    "category": "actor",
-                    "displayName": "John Saxon"
-                },
-                {
-                    "id": 7313,
-                    "category": "actor",
-                    "displayName": "Bruce Lee"
-                },
-                {
-                    "id": 7314,
-                    "category": "director",
-                    "displayName": "Robert Clouse"
-                },
-                {
-                    "id": 15010,
-                    "category": "actor",
-                    "displayName": "Jim Kelly"
-                },
-                {
-                    "id": 15011,
-                    "category": "actor",
-                    "displayName": "Ahna Capri"
-                }
-            ],
-            "pictures": [
-                {
-                    "entity": "picture",
-                    "id": 2853,
-                    "modifiedAt": "2014-03-28T00:25:46Z",
-                    "credits": "Tom Smith",
-                    "orientation": "portrait",
-                    "pictureType": "poster",
-                    "title": "",
-                    "versions": [
-                        {
-                            "profile": "webLandscapeSmall",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile150Image.jpg",
-                            "width": "192",
-                            "height": "108"
-                        },
-                        {
-                            "profile": "webLandscapeMedium",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "224",
-                            "height": "126"
-                        },
-                        {
-                            "profile": "webLandscapeLarge",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "384",
-                            "height": "216"
-                        },
-                        {
-                            "profile": "mobileLandscapeSmall",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "96",
-                            "height": "54"
-                        },
-                        {
-                            "profile": "mobileLandscapeMedium",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "160",
-                            "height": "90"
-                        },
-                        {
-                            "profile": "mobileLandscapeLarge",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "320",
-                            "height": "180"
-                        },
-                        {
-                            "profile": "mobileRetinaLandscapeSmall",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "192",
-                            "height": "108"
-                        },
-                        {
-                            "profile": "mobileRetinaLandscapeMedium",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "320",
-                            "height": "180"
-                        },
-                        {
-                            "profile": "mobileRetinaLandscapeLarge",
-                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
-                            "width": "640",
-                            "height": "360"
-                        }
-                    ]
-                }
-            ],
-            "seasons": null,
-            "videos": [
-                {
-                    "entity": "video",
-                    "id": 4533,
-                    "audioLanguage": {
-                        "id": 3,
-                        "title": "English"
-                    },
-                    "audioType": "stereo",
-                    "definition": "SD",
-                    "duration": 3642,
-                    "files": [
-                        {
-                           "path": "http://vodhds-video.cablevision.veo.tv/veo_4533/veo_4533__CV_MP4_SD_16x9_1600kbps_640x480_29.97fps.f4m",
-                           "type": "hds"
-                        },
-                        {
-                           "path": "http://vodhls-video.cablevision.veo.tv/veo_4533__CV/veo_4533__CV.m3u8",
-                           "type": "hls"
-                        },
-                        {
-                           "path": "http://vodss-video.cablevision.veo.tv/veo_4533__CV/veo_4533__CV.ism/Manifest",
-                           "type": "ss"
-                        }
-                    ],
-                    "resolution": "480i",
-                    "screenFormat": "widescreen",
-                    "videoType": "full"
-                }
-            ],
-            "publicationEvent": {
-                "entity": "publicationEvent",
-                "id": 18563,
-                "modifiedAt": "2014-08-07T02:50:31Z",
-                "startDate": "2014-04-09T06:00:00Z",
-                "endDate": "2015-03-31T05:59:00Z",
-                "billingType": "rental",
-                "price": "25.00"
-            },
-            "view": {
-              "position" : 20,
-              "current"  : false
-            }
+      "headers": {},
+      "data": {
+        "distributor": {
+          "entity": "distributor",
+          "id": 1,
+          "title": "televisa.networks.mx"
         },
-        "messages": []
+        "duration": 4620,
+        "entity": "asset",
+        "genre": {
+          "entity": "genre",
+          "id": 259,
+          "items": [],
+          "parent": null,
+          "title": "Talk Shows"
+        },
+        "id": 75,
+        "keywords": null,
+        "modifiedAt": "2014-09-05T03:52:50Z",
+        "otherGenres": [
+          {
+            "entity": "genre",
+            "id": 104,
+            "items": [
+              {
+                "entity": "genre",
+                "id": 500,
+                "items": [],
+                "parent": {
+                  "id": 104
+                },
+                "title": "Concierto"
+              }
+            ],
+            "parent": null,
+            "title": "Entretenimiento"
+          },
+          {
+            "entity": "genre",
+            "id": 259,
+            "items": [],
+            "parent": null,
+            "title": "Talk Shows"
+          }
+        ],
+        "people": [],
+        "pictures": [],
+        "studio": null,
+        "synopsis": "Esta noche la incomparable voz de Natalia Sosa, el comediante Gustavo Mungu\u00eda; y en la m\u00fasica, Babas\u00f3nicos, Mart\u00edn sobrino y los due\u00f1os del segundo piso.\n",
+        "synopsisShort": "Esta noche la incomparable voz de Natalia Sosa, el comediante Gustavo Mungu\u00eda; y en la m\u00fasica, Babas\u00f3nicos, Mart\u00edn sobrino y los due\u00f1os del segundo piso.\n",
+        "title": "Episodio 1",
+        "titleSeo": "",
+        "titleShort": "Episodio 1",
+        "category": "episode",
+        "parentShow": {
+          "entity": "asset",
+          "id": 71,
+          "title": "Es de Noche y ya Llegu\u00e9",
+          "category": "series"
+        },
+        "episodeNumber": 1,
+        "airDate": "2012-01-03T00:00:00Z",
+        "parentalRating": {
+          "entity": "parentalRating",
+          "id": 3,
+          "items": [],
+          "parent": null,
+          "title": "PG-13"
+        },
+        "publicationEvent": {
+          "billingType": "subscription",
+          "endDate": "2020-12-31T23:59:00Z",
+          "entity": "publicationEvent",
+          "id": 283,
+          "price": "0.00",
+          "startDate": "2012-01-03T00:00:00Z"
+        },
+        "videos": [
+          {
+            "definition": "SD",
+            "duration": 0,
+            "entity": "video",
+            "files": [
+              {
+                "entity": "videoFile",
+                "id": 110780,
+                "path": "http:\/\/vodhds-video.cablevision.veo.tv\/veo_70\/veo_70__CV_MP4_4x3_1600kbps_640x480_29.97fps.f4m",
+                "type": "hds"
+              },
+              {
+                "entity": "videoFile",
+                "id": 110781,
+                "path": "http:\/\/vodhls-video.cablevision.veo.tv\/veo_70__CV\/veo_70__CV.m3u8",
+                "type": "hls"
+              },
+              {
+                "entity": "videoFile",
+                "id": 110782,
+                "type": "isma"
+              },
+              {
+                "entity": "videoFile",
+                "id": 110783,
+                "path": "http:\/\/vodss-video.cablevision.veo.tv\/veo_70__CV\/veo_70__CV.ism\/Manifest",
+                "type": "ss"
+              },
+              {
+                "entity": "videoFile",
+                "id": 110784,
+                "type": "ismc"
+              }
+            ],
+            "id": 70
+          }
+        ],
+        "averageRating": 3,
+        "view": {
+          "position" : 734,
+          "current"  : false
+        }
+      },
+      "messages": []
     }
     ```
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1840,6 +1840,8 @@ Retrieves all assets.
 
     [List Assets][]
 
+
+
 # Group Channel
 Represents actions against Channel objects
 
@@ -18946,6 +18948,932 @@ Retrieves all Parental Rating.
 + Response 200
 
     [List Parental Rating][]
+
+
+# Group PlayResume
+Represents actions to resume play
+
+## PlayResume [/play/resume]
+Represent viewed assets
+
+### Retrieve the viewed assets [GET]
+List of viewed assets.
+
++ Response 200
+
+  ```js
+  {
+      "headers": {"ttl": 0, "total": 1},
+      "data": [
+        {
+            "entity": "asset",
+            "category": "movie",
+            "parentShow": null,
+            "id": 4754,
+            "title": "Operación Dragón",
+            "titleShort": "Operación Dragón",
+            "synopsisShort": "Un maestro de artes marciales decide espiar a un solitario criminal usando su invitación a un torneo.",
+            "duration": 3642,
+            "parentalRating": {
+                "id": 9,
+                "title": "R"
+            },
+            "genre": {
+                "id": 111,
+                "title": "Acción y Aventura"
+            },
+            "pictures": [
+                {
+                    "entity": "picture",
+                    "id": 2853,
+                    "modifiedAt": "2014-03-28T00:25:46Z",
+                    "credits": "Tom Smith",
+                    "orientation": "portrait",
+                    "pictureType": "poster",
+                    "title": "",
+                    "versions": [
+                        {
+                            "profile": "webLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile150Image.jpg",
+                            "width": "192",
+                            "height": "108"
+                        },
+                        {
+                            "profile": "webLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "224",
+                            "height": "126"
+                        },
+                        {
+                            "profile": "webLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "384",
+                            "height": "216"
+                        },
+                        {
+                            "profile": "mobileLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "96",
+                            "height": "54"
+                        },
+                        {
+                            "profile": "mobileLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "160",
+                            "height": "90"
+                        },
+                        {
+                            "profile": "mobileLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "320",
+                            "height": "180"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "192",
+                            "height": "108"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "320",
+                            "height": "180"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "640",
+                            "height": "360"
+                        }
+                    ]
+                }
+            ],
+            "publicationEvent": {
+                "entity": "publicationEvent",
+                "id": 18563,
+                "startDate": "2014-04-09T06:00:00Z",
+                "endDate": "2015-03-31T05:59:00Z",
+                "billingType": "rental",
+                "price": "25.00"
+            }
+        },
+        {
+            "entity": "asset",
+            "category": "series",
+            "parentShow": null,
+            "id": 11173,
+            "modifiedAt": "2014-08-07T02:50:31Z",
+            "title": "La Viuda Negra",
+            "titleShort": "La Viuda Negra",
+            "synopsisShort": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida.",
+            "synopsis": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida, pero a un alto precio.",
+            "duration": 3642,
+            "airDate": "2008-06-17T10:23:36Z",
+            "externalBillingId": "000557397",
+            "parentalRating": {
+                "id": 9,
+                "title": "R"
+            },
+            "genre": {
+                "id": 111,
+                "title": "Acción y Aventura"
+            },
+            "pictures": [
+                {
+                    "entity": "picture",
+                    "id": 2853,
+                    "modifiedAt": "2014-03-28T00:25:46Z",
+                    "credits": "Tom Smith",
+                    "orientation": "portrait",
+                    "pictureType": "poster",
+                    "title": "",
+                    "versions": [
+                        {
+                            "profile": "webLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile150Image.jpg",
+                            "width": "192",
+                            "height": "108"
+                        },
+                        {
+                            "profile": "webLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "224",
+                            "height": "126"
+                        },
+                        {
+                            "profile": "webLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "384",
+                            "height": "216"
+                        },
+                        {
+                            "profile": "mobileLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "96",
+                            "height": "54"
+                        },
+                        {
+                            "profile": "mobileLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "160",
+                            "height": "90"
+                        },
+                        {
+                            "profile": "mobileLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "320",
+                            "height": "180"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "192",
+                            "height": "108"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "320",
+                            "height": "180"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "640",
+                            "height": "360"
+                        }
+                    ]
+                }
+            ],
+            "seasons": [
+                {
+                    "entity": "season",
+                    "id": 451,
+                    "title": null,
+                    "number": 1,
+                    "episodeCount": 0,
+                    "airDate": "2008-06-17T10:23:36Z"
+                },
+                {
+                    "entity": "season",
+                    "id": 462,
+                    "title": null,
+                    "number": 2,
+                    "episodeCount": 0,
+                    "airDate": "2008-06-17T10:23:36Z"
+                }
+            ],
+            "publicationEvent": {
+                "entity": "publicationEvent",
+                "id": 18563,
+                "modifiedAt": "2014-08-07T02:50:31Z",
+                "startDate": "2014-04-09T06:00:00Z",
+                "endDate": "2015-03-31T05:59:00Z",
+                "billingType": "rental",
+                "price": "25.00"
+            }
+        },
+        {
+            "headers": {"ttl": 0},
+            "data": {
+                "entity": "asset",
+                "category": "episode",
+                "parentShow": {
+                    "entity": "asset",
+                    "category": "series",
+                    "id": 11173
+                },
+                "id": 11174,
+                "modifiedAt": "2014-08-07T02:50:31Z",
+                "title": "Abusan de Griselda",
+                "titleShort": "Abusan de Griselda",
+                "synopsisShort": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida.",
+                "synopsis": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida, pero a un alto precio.",
+                "duration": 3642,
+                "airDate": "2008-06-17T10:23:36Z",
+                "externalBillingId": "000557397",
+                "parentalRating": {
+                    "id": 9,
+                    "title": "R"
+                },
+                "genre": {
+                    "id": 111,
+                    "title": "Acción y Aventura"
+                },
+                "publicationEvent": {
+                    "entity": "publicationEvent",
+                    "id": 18563,
+                    "modifiedAt": "2014-08-07T02:50:31Z",
+                    "startDate": "2014-04-09T06:00:00Z",
+                    "endDate": "2015-03-31T05:59:00Z",
+                    "billingType": "rental",
+                    "price": "25.00"
+                }
+            },
+            "messages": []
+        }
+      ],
+      "messages": []
+  }
+  ```
+
+
+## Retrieve data for a viewed asset [/play/resume/{assetId}]
+Return information specific to a given asset, including the view object.
+
++ Parameters
+    + assetId (integer) ... The asset id.
+
+
+### Retrieve asset info [GET]
+Retrieves the info for the given asset.
+
+
++ Response 200
+
+    ```js
+    {
+        "headers": {"ttl": 0},
+        "data": {
+            "entity": "asset",
+            "category": "movie",
+            "parentShow": null,
+            "id": 4754,
+            "modifiedAt": "2014-08-07T02:50:31Z",
+            "title": "Operación Dragón",
+            "titleShort": "Operación Dragón",
+            "synopsisShort": "Un maestro de artes marciales decide espiar a un solitario criminal usando su invitación a un torneo.",
+            "synopsis": "Un maestro de artes marciales decide espiar a un solitario criminal usando su invitación a un torneo. Es la película que tras estrenarse en Hong Kong, dio a conocer a Bruce Lee en Estados Unidos.",
+            "keywords": [
+                "dragon",
+                "ball"
+            ],
+            "duration": 3642,
+            "airDate": "2008-06-17T10:23:36Z",
+            "externalBillingId": "000557397",
+            "parentalRating": {
+                "id": 9,
+                "title": "R"
+            },
+            "genre": {
+                "id": 111,
+                "title": "Acción y Aventura"
+            },
+            "otherGenres": [
+                {
+                    "id": 111,
+                    "title": "Acción y Aventura"
+                },
+                {
+                    "id": 112,
+                    "title": "Dibujos Animados"
+                }
+            ],
+            "distributor": {
+                "id": 12,
+                "title": "Warner Bros."
+            },
+            "studio": {
+                "id": 22,
+                "title": "WDD"
+            },
+            "people": [
+                {
+                    "id": 7312,
+                    "category": "actor",
+                    "displayName": "John Saxon"
+                },
+                {
+                    "id": 7313,
+                    "category": "actor",
+                    "displayName": "Bruce Lee"
+                },
+                {
+                    "id": 7314,
+                    "category": "director",
+                    "displayName": "Robert Clouse"
+                },
+                {
+                    "id": 15010,
+                    "category": "actor",
+                    "displayName": "Jim Kelly"
+                },
+                {
+                    "id": 15011,
+                    "category": "actor",
+                    "displayName": "Ahna Capri"
+                }
+            ],
+            "pictures": [
+                {
+                    "entity": "picture",
+                    "id": 2853,
+                    "modifiedAt": "2014-03-28T00:25:46Z",
+                    "credits": "Tom Smith",
+                    "orientation": "portrait",
+                    "pictureType": "poster",
+                    "title": "",
+                    "versions": [
+                        {
+                            "profile": "webLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile150Image.jpg",
+                            "width": "192",
+                            "height": "108"
+                        },
+                        {
+                            "profile": "webLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "224",
+                            "height": "126"
+                        },
+                        {
+                            "profile": "webLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "384",
+                            "height": "216"
+                        },
+                        {
+                            "profile": "mobileLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "96",
+                            "height": "54"
+                        },
+                        {
+                            "profile": "mobileLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "160",
+                            "height": "90"
+                        },
+                        {
+                            "profile": "mobileLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "320",
+                            "height": "180"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "192",
+                            "height": "108"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "320",
+                            "height": "180"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "640",
+                            "height": "360"
+                        }
+                    ]
+                }
+            ],
+            "videos": [
+                {
+                    "entity": "video",
+                    "id": 4533,
+                    "audioLanguage": {
+                        "id": 3,
+                        "title": "English"
+                    },
+                    "audioType": "stereo",
+                    "definition": "SD",
+                    "duration": 3642,
+                    "files": [
+                        {
+                           "path": "http://vodhds-video.cablevision.veo.tv/veo_4533/veo_4533__CV_MP4_SD_16x9_1600kbps_640x480_29.97fps.f4m",
+                           "type": "hds"
+                        },
+                        {
+                           "path": "http://vodhls-video.cablevision.veo.tv/veo_4533__CV/veo_4533__CV.m3u8",
+                           "type": "hls"
+                        },
+                        {
+                           "path": "http://vodss-video.cablevision.veo.tv/veo_4533__CV/veo_4533__CV.ism/Manifest",
+                           "type": "ss"
+                        }
+                    ],
+                    "resolution": "480i",
+                    "screenFormat": "widescreen",
+                    "videoType": "full"
+                }
+            ],
+            "publicationEvent": {
+                "entity": "publicationEvent",
+                "id": 18563,
+                "modifiedAt": "2014-08-07T02:50:31Z",
+                "startDate": "2014-04-09T06:00:00Z",
+                "endDate": "2015-03-31T05:59:00Z",
+                "billingType": "rental",
+                "price": "25.00"
+            },
+            "view": {
+              "position" : 20,
+              "current"  : false
+            }
+        },
+        "messages": []
+    }
+    ```
+
++ Response 201
+
+    ```js
+    {
+        "headers": {"ttl": 0},
+        "data": {
+            "entity": "asset",
+            "category": "series",
+            "parentShow": null,
+            "id": 11173,
+            "modifiedAt": "2014-08-07T02:50:31Z",
+            "title": "La Viuda Negra",
+            "titleShort": "La Viuda Negra",
+            "synopsisShort": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida.",
+            "synopsis": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida, pero a un alto precio.",
+            "keywords": [
+                "dragon",
+                "ball"
+            ],
+            "duration": 3642,
+            "airDate": "2008-06-17T10:23:36Z",
+            "externalBillingId": "000557397",
+            "parentalRating": {
+                "id": 9,
+                "title": "R"
+            },
+            "genre": {
+                "id": 111,
+                "title": "Acción y Aventura"
+            },
+            "otherGenres": [
+                {
+                    "id": 111,
+                    "title": "Acción y Aventura"
+                },
+                {
+                    "id": 112,
+                    "title": "Dibujos Animados"
+                }
+            ],
+            "distributor": {
+                "id": 12,
+                "title": "Warner Bros."
+            },
+            "studio": {
+                "id": 22,
+                "title": "WDD"
+            },
+            "people": [
+                {
+                    "id": 7312,
+                    "category": "actor",
+                    "displayName": "John Saxon"
+                },
+                {
+                    "id": 7313,
+                    "category": "actor",
+                    "displayName": "Bruce Lee"
+                },
+                {
+                    "id": 7314,
+                    "category": "director",
+                    "displayName": "Robert Clouse"
+                },
+                {
+                    "id": 15010,
+                    "category": "actor",
+                    "displayName": "Jim Kelly"
+                },
+                {
+                    "id": 15011,
+                    "category": "actor",
+                    "displayName": "Ahna Capri"
+                }
+            ],
+            "pictures": [
+                {
+                    "entity": "picture",
+                    "id": 2853,
+                    "modifiedAt": "2014-03-28T00:25:46Z",
+                    "credits": "Tom Smith",
+                    "orientation": "portrait",
+                    "pictureType": "poster",
+                    "title": "",
+                    "versions": [
+                        {
+                            "profile": "webLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile150Image.jpg",
+                            "width": "192",
+                            "height": "108"
+                        },
+                        {
+                            "profile": "webLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "224",
+                            "height": "126"
+                        },
+                        {
+                            "profile": "webLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "384",
+                            "height": "216"
+                        },
+                        {
+                            "profile": "mobileLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "96",
+                            "height": "54"
+                        },
+                        {
+                            "profile": "mobileLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "160",
+                            "height": "90"
+                        },
+                        {
+                            "profile": "mobileLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "320",
+                            "height": "180"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "192",
+                            "height": "108"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "320",
+                            "height": "180"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "640",
+                            "height": "360"
+                        }
+                    ]
+                }
+            ],
+            "seasons": [
+                {
+                    "entity": "season",
+                    "id": 451,
+                    "title": null,
+                    "number": 1,
+                    "episodeCount": 0,
+                    "airDate": "2008-06-17T10:23:36Z",
+                    "episodes": [
+                        {
+                            "entity": "asset",
+                            "category": "episode",
+                            "id": 11392,
+                            "episodeNumber": 40,
+                            "title": "Fuera de todo plan",
+                            "titleShort": "Fuera de todo plan",
+                            "synopsisShort": "El Legado",
+                            "pictures": [
+                                {
+                                    "entity": "picture",
+                                    "id": 2853,
+                                    "modifiedAt": "2014-03-28T00:25:46Z",
+                                    "pictureType": "poster",
+                                    "title": ""
+                                }
+                            ],
+                            "view": {
+                              "position" : 30,
+                              "current"  : true
+                            }
+                        },
+                        {
+                            "entity": "asset",
+                            "category": "episode",
+                            "id": 11569,
+                            "episodeNumber": 39,
+                            "title": "Griselda se confiesa",
+                            "titleShort": "Griselda se confiesa",
+                            "synopsisShort": "Griselda le cuenta a una guardia del reclusorio que Jones le confesó su amor y que nunca trató de hacerle daño. Mientras, Otálvaro planea la venganza por la muerte de su sobrina.",
+                            "pictures": [
+                                {
+                                    "entity": "picture",
+                                    "id": 2853,
+                                    "modifiedAt": "2014-03-28T00:25:46Z",
+                                    "pictureType": "poster",
+                                    "title": ""
+                                }
+                            ],
+                            "view": {
+                              "position" : 22,
+                              "current"  : false
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entity": "season",
+                    "id": 462,
+                    "title": null,
+                    "number": 2,
+                    "episodeCount": 0,
+                    "airDate": "2008-06-17T10:23:36Z",
+                    "episodes": [
+                        {
+                            "entity": "asset",
+                            "category": "episode",
+                            "id": 12780,
+                            "episodeNumber": 81,
+                            "title": "El Legado",
+                            "titleShort": "El Legado",
+                            "synopsisShort": "Griselda se ve enfrentada a una trampa de García mientras Jones se encarga del rescate. García finalmente embosca a Griselda y a Richie, quienes deciden llevar a cabo un plan para evitar ser capturados. Michael toma cartas en este asunto y pone en la mira a García.",
+                            "pictures": [
+                                {
+                                    "entity": "picture",
+                                    "id": 2853,
+                                    "modifiedAt": "2014-03-28T00:25:46Z",
+                                    "pictureType": "poster",
+                                    "title": ""
+                                }
+                            ]
+                        },
+                        {
+                            "entity": "asset",
+                            "category": "episode",
+                            "id": 12781,
+                            "episodeNumber": 80,
+                            "title": "Lucha de astucias",
+                            "titleShort": "Lucha de astucias",
+                            "synopsisShort": "Jennifer rescata a Jones de un barranco, en tanto que Griselda y Silvio finalmente se enfrentan: sólo uno saldrá con vida. Jennifer y Jones tienen claro que capturar a Griselda es ahora su prioridad.",
+                            "pictures": [
+                                {
+                                    "entity": "picture",
+                                    "id": 2853,
+                                    "modifiedAt": "2014-03-28T00:25:46Z",
+                                    "pictureType": "poster",
+                                    "title": ""
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "videos": [],
+            "publicationEvent": {
+                "entity": "publicationEvent",
+                "id": 18563,
+                "modifiedAt": "2014-08-07T02:50:31Z",
+                "startDate": "2014-04-09T06:00:00Z",
+                "endDate": "2015-03-31T05:59:00Z",
+                "billingType": "rental",
+                "price": "25.00"
+            }
+        },
+        "messages": []
+    }
+    ```
+
++ Response 202
+
+    ```js
+    {
+        "headers": {"ttl": 0},
+        "data": {
+            "entity": "asset",
+            "category": "episode",
+            "parentShow": {
+                "entity": "asset",
+                "category": "series",
+                "id": 11173
+            },
+            "id": 11174,
+            "modifiedAt": "2014-08-07T02:50:31Z",
+            "title": "Abusan de Griselda",
+            "titleShort": "Abusan de Griselda",
+            "synopsisShort": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida.",
+            "synopsis": "Griselda Blanco, \"la patrona\" de Pablo Escobar, usa al narco para vengar sus profundas decepciones de vida, pero a un alto precio.",
+            "keywords": [
+                "dragon",
+                "ball"
+            ],
+            "duration": 3642,
+            "airDate": "2008-06-17T10:23:36Z",
+            "externalBillingId": "000557397",
+            "parentalRating": {
+                "id": 9,
+                "title": "R"
+            },
+            "genre": {
+                "id": 111,
+                "title": "Acción y Aventura"
+            },
+            "otherGenres": [
+                {
+                    "id": 111,
+                    "title": "Acción y Aventura"
+                },
+                {
+                    "id": 112,
+                    "title": "Dibujos Animados"
+                }
+            ],
+            "distributor": {
+                "id": 12,
+                "title": "Warner Bros."
+            },
+            "studio": {
+                "id": 22,
+                "title": "WDD"
+            },
+            "people": [
+                {
+                    "id": 7312,
+                    "category": "actor",
+                    "displayName": "John Saxon"
+                },
+                {
+                    "id": 7313,
+                    "category": "actor",
+                    "displayName": "Bruce Lee"
+                },
+                {
+                    "id": 7314,
+                    "category": "director",
+                    "displayName": "Robert Clouse"
+                },
+                {
+                    "id": 15010,
+                    "category": "actor",
+                    "displayName": "Jim Kelly"
+                },
+                {
+                    "id": 15011,
+                    "category": "actor",
+                    "displayName": "Ahna Capri"
+                }
+            ],
+            "pictures": [
+                {
+                    "entity": "picture",
+                    "id": 2853,
+                    "modifiedAt": "2014-03-28T00:25:46Z",
+                    "credits": "Tom Smith",
+                    "orientation": "portrait",
+                    "pictureType": "poster",
+                    "title": "",
+                    "versions": [
+                        {
+                            "profile": "webLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile150Image.jpg",
+                            "width": "192",
+                            "height": "108"
+                        },
+                        {
+                            "profile": "webLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "224",
+                            "height": "126"
+                        },
+                        {
+                            "profile": "webLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "384",
+                            "height": "216"
+                        },
+                        {
+                            "profile": "mobileLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "96",
+                            "height": "54"
+                        },
+                        {
+                            "profile": "mobileLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "160",
+                            "height": "90"
+                        },
+                        {
+                            "profile": "mobileLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "320",
+                            "height": "180"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeSmall",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "192",
+                            "height": "108"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeMedium",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "320",
+                            "height": "180"
+                        },
+                        {
+                            "profile": "mobileRetinaLandscapeLarge",
+                            "link": "https://cdnassets.veo.tv/prod/Picture/C_1_Picture_7315_profile151Image.jpg",
+                            "width": "640",
+                            "height": "360"
+                        }
+                    ]
+                }
+            ],
+            "seasons": null,
+            "videos": [
+                {
+                    "entity": "video",
+                    "id": 4533,
+                    "audioLanguage": {
+                        "id": 3,
+                        "title": "English"
+                    },
+                    "audioType": "stereo",
+                    "definition": "SD",
+                    "duration": 3642,
+                    "files": [
+                        {
+                           "path": "http://vodhds-video.cablevision.veo.tv/veo_4533/veo_4533__CV_MP4_SD_16x9_1600kbps_640x480_29.97fps.f4m",
+                           "type": "hds"
+                        },
+                        {
+                           "path": "http://vodhls-video.cablevision.veo.tv/veo_4533__CV/veo_4533__CV.m3u8",
+                           "type": "hls"
+                        },
+                        {
+                           "path": "http://vodss-video.cablevision.veo.tv/veo_4533__CV/veo_4533__CV.ism/Manifest",
+                           "type": "ss"
+                        }
+                    ],
+                    "resolution": "480i",
+                    "screenFormat": "widescreen",
+                    "videoType": "full"
+                }
+            ],
+            "publicationEvent": {
+                "entity": "publicationEvent",
+                "id": 18563,
+                "modifiedAt": "2014-08-07T02:50:31Z",
+                "startDate": "2014-04-09T06:00:00Z",
+                "endDate": "2015-03-31T05:59:00Z",
+                "billingType": "rental",
+                "price": "25.00"
+            },
+            "view": {
+              "position" : 20,
+              "current"  : false
+            }
+        },
+        "messages": []
+    }
+    ```
+
 
 # Group PlayContext
 Actions required for playing and tracking video streaming


### PR DESCRIPTION
https://televisa.atlassian.net/browse/SB-1759

I created 2 responses:

1 /play/resume  retrieve the viewed assets
    This one is a list of assets(each one just with basic properties, no episode list for series, no people collection, ect) and without the view object.

2 /play/resume/{assetId}  retrieve asset info
    This response return an asset ( determined by assetId) object with all its properties and the view object in it (the view object has two properties, position(integer) and current(boolean). In case the asset is a series, an array of seasons and its episodes with the view object.
I provided 3 responses (200 => movie, 201 => series, 202 => episode) for more information and testing purposes.
I modified “number" to “episodeNumber" in episodes objects.
